### PR TITLE
Fix export button double-click issue after navigation

### DIFF
--- a/src/components/bottom-toolbar.tsx
+++ b/src/components/bottom-toolbar.tsx
@@ -18,6 +18,7 @@ interface BottomToolbarProps {
 
 export function BottomToolbar({ onExport, onFormatChange, onSettings, selectedFormat, isDownloading = false, className = '', onExpandedChange, expandedPanel, onExpandedPanelChange }: BottomToolbarProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const exportButtonRef = React.useRef<HTMLButtonElement>(null);
 
   const handleExpandedChange = (expanded: boolean) => {
     setIsExpanded(expanded);
@@ -165,10 +166,22 @@ export function BottomToolbar({ onExport, onFormatChange, onSettings, selectedFo
         <div className="bg-white/95 backdrop-blur-xl border-t border-gray-200/50" style={{ position: 'relative', contain: 'layout' }}>
           <div className="flex items-center justify-around py-2" style={{ paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))' }}>
             <button
-              onClick={() => handlePanelChange(expandedPanel === 'export' ? null : 'export')}
-              onMouseDown={(e) => e.preventDefault()}
-              className="p-2 rounded-lg hover:bg-gray-100 transition-colors group"
+              ref={exportButtonRef}
+              onClick={(e) => {
+                e.stopPropagation();
+                handlePanelChange(expandedPanel === 'export' ? null : 'export');
+              }}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onTouchStart={(e) => {
+                e.stopPropagation();
+              }}
+              className="p-2 rounded-lg hover:bg-gray-100 transition-colors group touch-manipulation"
               aria-label="Export"
+              type="button"
+              style={{ WebkitTapHighlightColor: 'transparent' }}
             >
               <Download className="w-5 h-5 text-gray-700 group-hover:text-orange-500 transition-colors" />
             </button>

--- a/src/components/bottom-toolbar.tsx
+++ b/src/components/bottom-toolbar.tsx
@@ -166,6 +166,7 @@ export function BottomToolbar({ onExport, onFormatChange, onSettings, selectedFo
           <div className="flex items-center justify-around py-2" style={{ paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))' }}>
             <button
               onClick={() => handlePanelChange(expandedPanel === 'export' ? null : 'export')}
+              onMouseDown={(e) => e.preventDefault()}
               className="p-2 rounded-lg hover:bg-gray-100 transition-colors group"
               aria-label="Export"
             >


### PR DESCRIPTION
## Summary
- Fixed issue where export button required double-click after navigating through months
- Improved button event handling for better mobile responsiveness

## Changes
- Added preventDefault and stopPropagation to handle focus/click events properly
- Added touch event handlers for mobile devices
- Removed webkit tap highlight for cleaner interaction
- Added explicit button type and touch-manipulation class

## Test plan
- [x] Navigate through months using arrow buttons
- [x] Click export button - should open on first click
- [x] Test on mobile devices for touch responsiveness

🤖 Generated with [Claude Code](https://claude.ai/code)